### PR TITLE
validate connection state as well as presence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knex-snowflake-dialect",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "knex-snowflake-dialect",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-snowflake-dialect",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "knex.js dialect for the Snowflake data warehouse",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,11 +164,7 @@ export class SnowflakeDialect extends knex.Client {
   }
 
   async validateConnection(connection: any): Promise<boolean> {
-    if (connection) {
-      return true;
-    }
-
-    return false;
+    return !!connection?.isUp();
   }
 
   // Runs the query on the specified connection, providing the bindings


### PR DESCRIPTION
When cancelling a connection it's left in a bad state.  The connection validation code needs to check the connection state instead of just presence, this seems to eventually fill the connection pool with bad connections.